### PR TITLE
fixed call of tarantool_schema_destroy to tarantool_schema_delete

### DIFF
--- a/src/tarantool_manager.c
+++ b/src/tarantool_manager.c
@@ -93,7 +93,7 @@ int manager_entry_dequeue_delete (struct manager_entry *entry) {
 	if (pval->greeting)      pefree(pval->greeting, 1);
 	if (pval->persistent_id) pefree(pval->persistent_id, 1);
 	if (pval->schema) {
-		tarantool_schema_destroy(pval->schema);
+		tarantool_schema_delete(pval->schema);
 		pval->schema = NULL;
 	}
 	if (entry->value.begin == entry->value.end)


### PR DESCRIPTION
```
$ php -v
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php5/20131226/tarantool.so' - /usr/lib/php5/20131226/tarantool.so: undefined symbol: tarantool_schema_destroy in Unknown on line 0
PHP 5.6.7-1+deb.sury.org~trusty+1 (cli) (built: Mar 24 2015 11:21:10) 
Copyright (c) 1997-2015 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
    with Zend OPcache v7.0.4-dev, Copyright (c) 1999-2015, by Zend Technologies
```