### PR TITLE
fix crash when header was not an array

### DIFF
--- a/src/tarantool.c
+++ b/src/tarantool.c
@@ -348,7 +348,7 @@ static int64_t tarantool_step_recv(
 		THROW_EXC("Failed verifying msgpack");
 		goto error;
 	}
-	if (php_mp_unpack(header, &pos) == FAILURE) {
+	if (php_mp_unpack(header, &pos) == FAILURE || Z_TYPE_PP(header) != IS_ARRAY) {
 		*header = NULL;
 		goto error;
 	}


### PR DESCRIPTION
The code checks if header was unpacked successfully, but doesn't check if it's an array before using it as such, which leads to crashes since zend_hash_*() functions do not expect hash to be NULL.