### PR TITLE
Extern smart_str_nullify()

### DIFF
--- a/src/tarantool.c
+++ b/src/tarantool.c
@@ -25,6 +25,8 @@
 #include "tarantool_schema.h"
 #include "tarantool_tp.h"
 
+void smart_str_nullify(smart_str *str);
+
 ZEND_DECLARE_MODULE_GLOBALS(tarantool)
 
 #ifdef HAVE_CONFIG_H

--- a/src/tarantool_msgpack.c
+++ b/src/tarantool_msgpack.c
@@ -28,7 +28,7 @@ int smart_str_ensure(smart_str *str, size_t len) {
 	return 0;
 }
 
-inline void smart_str_nullify(smart_str *str) {
+void smart_str_nullify(smart_str *str) {
 	memset(SSTR_BEG(str), 0, SSTR_AWA(str));
 }
 


### PR DESCRIPTION
smart_str_nullify() is used in src/tarantool.c but declared in src/tarantool_msgpack.c as inline. It gives to a compiler right to optimize it out so that this symbol appears to be undefined on linkage stage. 
Problem appeared on OSX 10.11.2 (Apple LLVM version 7.0.2 (clang-700.1.81))