### PR TITLE
Fix build error

### DIFF
--- a/src/tarantool_network.c
+++ b/src/tarantool_network.c
@@ -40,7 +40,6 @@ void tntll_stream_close(php_stream *stream, zend_string *pid) {
 int tntll_stream_fpid2(zend_string *pid, php_stream **ostream) {
 	TSRMLS_FETCH();
 	return php_stream_from_persistent_id(pid->val, ostream TSRMLS_CC);
-	return rv;
 }
 
 int tntll_stream_fpid(const char *host, int port, zend_string *pid,


### PR DESCRIPTION
This fixes the build error:
```sh
/tmp/tarantool-php/src/tarantool_network.c: In function 'tntll_stream_fpid2':
/tmp/tarantool-php/src/tarantool_network.c:43:9: error: 'rv' undeclared (first use in this function)
  return rv;
         ^~
/tmp/tarantool-php/src/tarantool_network.c:43:9: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:195: src/tarantool_network.lo] Error 1
```


