### PR TITLE
Method for closing all persistent connections at once

### DIFF
--- a/src/php_tarantool.h
+++ b/src/php_tarantool.h
@@ -79,6 +79,7 @@ PHP_METHOD(Tarantool, delete);
 PHP_METHOD(Tarantool, update);
 PHP_METHOD(Tarantool, upsert);
 PHP_METHOD(Tarantool, flush_schema);
+PHP_METHOD(Tarantool, close_all);
 
 ZEND_BEGIN_MODULE_GLOBALS(tarantool)
 	zend_bool persistent;

--- a/src/tarantool.c
+++ b/src/tarantool.c
@@ -562,7 +562,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_tarantool_upsert, 0, 0, 3)
 ZEND_END_ARG_INFO()
 
 #define TNT_MEP(name, args)        PHP_ME    (Tarantool,        name, args, ZEND_ACC_PUBLIC)
+#define TNT_MES(name, args)        PHP_ME    (Tarantool,        name, args, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 #define TNT_MAP(alias, name, args) PHP_MALIAS(Tarantool, alias, name, args, ZEND_ACC_PUBLIC)
+#define TNT_MAS(alias, name, args) PHP_MALIAS(Tarantool, alias, name, args, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 const zend_function_entry Tarantool_methods[] = {
 	TNT_MEP(__construct,                arginfo_tarantool_construct    )
 	TNT_MEP(connect,                    arginfo_tarantool_void         )
@@ -582,10 +584,14 @@ const zend_function_entry Tarantool_methods[] = {
 	TNT_MAP(evaluate,     eval,         arginfo_tarantool_proc_tuple   )
 	TNT_MAP(flushSchema,  flush_schema, arginfo_tarantool_void         )
 	TNT_MAP(disconnect,   close,        arginfo_tarantool_void         )
+	TNT_MES(close_all,                  arginfo_tarantool_void         )
+	TNT_MAS(closeAll,     close_all,    arginfo_tarantool_void         )
 	{NULL, NULL, NULL}
 };
 #undef TNT_MEP
+#undef TNT_MES
 #undef TNT_MAP
+#undef TNT_MAS
 
 /* ####################### HELPERS ####################### */
 
@@ -1281,6 +1287,16 @@ PHP_METHOD(Tarantool, close) {
 	TARANTOOL_FUNCTION_BEGIN(obj, id, "");
 
 	RETURN_TRUE;
+}
+
+PHP_METHOD(Tarantool, close_all) {
+	zval *zle;
+
+	ZEND_HASH_FOREACH_VAL(&EG(persistent_list), zle) {
+		if (Z_RES_TYPE_P(zle) == php_tarantool_list_entry()) {
+			tarantool_stream_close((tarantool_connection *) Z_RES_VAL_P(zle));
+		}
+	} ZEND_HASH_FOREACH_END();
 }
 
 PHP_METHOD(Tarantool, ping) {

--- a/src/tarantool_proto.h
+++ b/src/tarantool_proto.h
@@ -17,7 +17,7 @@
 
 #include <stdint.h>
 
-#include <php_tarantool.h>
+#include "php_tarantool.h"
 
 /**
  * Pack version into uint32_t.


### PR DESCRIPTION
You might really want to call this in some cases before starting pcntl_fork()'ing for parallel processing (e.g., heavy cli cron script) with persistent connections enabled