### PR TITLE
Fixing problem caused by non-server fields in space `:format()`

### DIFF
--- a/src/tarantool.c
+++ b/src/tarantool.c
@@ -271,7 +271,7 @@ retry:
 	while (count > 0) {
 		--count;
 		if (err) {
-			/* If we're here, then there war error */
+			/* If we're here, then there was error */
 			nanosleep(&sleep_time, NULL);
 			efree(err);
 			err = NULL;
@@ -301,7 +301,6 @@ retry:
 	}
 	if (count == 0) {
 ioexception:
-		// raise (SIGABRT);
 		tarantool_throw_ioexception("%s", err);
 		efree(err);
 		return FAILURE;

--- a/src/tarantool_schema.c
+++ b/src/tarantool_schema.c
@@ -232,6 +232,8 @@ parse_schema_space_value_value(struct schema_field_value *fld,
 			goto error;
 		sfield = mp_decode_str(tuple, &sfield_len);
 		fld->field_type = parse_field_type(sfield, sfield_len);
+	} else {
+		mp_next(tuple);
 	}
 	return 0;
 error:

--- a/test/DMLTest.php
+++ b/test/DMLTest.php
@@ -342,7 +342,7 @@ class DMLTest extends PHPUnit_Framework_TestCase
 				self::$tarantool->select("test_hash", null, null, null, null, TARANTOOL::ITERATOR_EQ);
 				$this->assertFalse(True);
 			} catch (TarantoolClientError $e) {
-				$this->assertContains('Invalid key part', $e->getMessage());
+				$this->assertRegExp('(Invalid key part|via a partial key)', $e->getMessage());
 			}
 		}
 
@@ -354,7 +354,7 @@ class DMLTest extends PHPUnit_Framework_TestCase
 				self::$tarantool->select($spc, null, null, null, null, $itype);
 				$this->assertFalse(True);
 			} catch (TarantoolClientError $e) {
-				$this->assertContains($xcmsg, $e->getMessage());
+				$this->assertRegExp($xcmsg, $e->getMessage());
 			}
 		}
 
@@ -384,40 +384,40 @@ class DMLTest extends PHPUnit_Framework_TestCase
 
 		public static function provideIteratorClientError() {
 			return [
-				['test_hash', 'EQ'                ,'Invalid key part'],
-				['test_hash', 'REQ'               ,'Invalid key part'],
-				['test_hash', 'LT'                ,'Invalid key part'],
-				['test_hash', 'LE'                ,'Invalid key part'],
-				['test_hash', 'GE'                ,'Invalid key part'],
-				['test_hash', 'BITSET_ALL_SET'    ,'Invalid key part'],
-				['test_hash', 'BITSET_ANY_SET'    ,'Invalid key part'],
-				['test_hash', 'BITSET_ALL_NOT_SET','Invalid key part'],
-				['test_hash', 'BITS_ALL_SET'      ,'Invalid key part'],
-				['test_hash', 'BITS_ANY_SET'      ,'Invalid key part'],
-				['test_hash', 'BITS_ALL_NOT_SET'  ,'Invalid key part'],
-				['test_hash', 'OVERLAPS'          ,'Invalid key part'],
-				['test_hash', 'NEIGHBOR'          ,'Invalid key part'],
-				['test_hash', 'eq'                ,'Invalid key part'],
-				['test_hash', 'req'               ,'Invalid key part'],
-				['test_hash', 'lt'                ,'Invalid key part'],
-				['test_hash', 'le'                ,'Invalid key part'],
-				['test_hash', 'ge'                ,'Invalid key part'],
-				['test_hash', 'bitset_all_set'    ,'Invalid key part'],
-				['test_hash', 'bitset_any_set'    ,'Invalid key part'],
-				['test_hash', 'bitset_all_not_set','Invalid key part'],
-				['test_hash', 'bits_all_set'      ,'Invalid key part'],
-				['test_hash', 'bits_any_set'      ,'Invalid key part'],
-				['test_hash', 'bits_all_not_set'  ,'Invalid key part'],
-				['test_hash', 'overlaps'          ,'Invalid key part'],
-				['test_hash', 'neighbor'          ,'Invalid key part'],
-				['test'     , 'bitset_all_set'    ,'does not support requested iterator type'],
-				['test'     , 'bitset_any_set'    ,'does not support requested iterator type'],
-				['test'     , 'bitset_all_not_set','does not support requested iterator type'],
-				['test'     , 'bits_all_set'      ,'does not support requested iterator type'],
-				['test'     , 'bits_any_set'      ,'does not support requested iterator type'],
-				['test'     , 'bits_all_not_set'  ,'does not support requested iterator type'],
-				['test'     , 'overlaps'          ,'does not support requested iterator type'],
-				['test'     , 'neighbor'          ,'does not support requested iterator type'],
+				['test_hash', 'EQ'                ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'REQ'               ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'LT'                ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'LE'                ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'GE'                ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'BITSET_ALL_SET'    ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'BITSET_ANY_SET'    ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'BITSET_ALL_NOT_SET','(Invalid key part|via a partial key)'],
+				['test_hash', 'BITS_ALL_SET'      ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'BITS_ANY_SET'      ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'BITS_ALL_NOT_SET'  ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'OVERLAPS'          ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'NEIGHBOR'          ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'eq'                ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'req'               ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'lt'                ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'le'                ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'ge'                ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'bitset_all_set'    ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'bitset_any_set'    ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'bitset_all_not_set','(Invalid key part|via a partial key)'],
+				['test_hash', 'bits_all_set'      ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'bits_any_set'      ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'bits_all_not_set'  ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'overlaps'          ,'(Invalid key part|via a partial key)'],
+				['test_hash', 'neighbor'          ,'(Invalid key part|via a partial key)'],
+				['test'     , 'bitset_all_set'    ,'(does not support requested iterator type)'],
+				['test'     , 'bitset_any_set'    ,'(does not support requested iterator type)'],
+				['test'     , 'bitset_all_not_set','(does not support requested iterator type)'],
+				['test'     , 'bits_all_set'      ,'(does not support requested iterator type)'],
+				['test'     , 'bits_any_set'      ,'(does not support requested iterator type)'],
+				['test'     , 'bits_all_not_set'  ,'(does not support requested iterator type)'],
+				['test'     , 'overlaps'          ,'(does not support requested iterator type)'],
+				['test'     , 'neighbor'          ,'(does not support requested iterator type)'],
 			];
 		}
 


### PR DESCRIPTION
For example:
```
    local space = box.schema.space.create('test', {
        format = {
            { type = compat.unsigned, name = 'field1', add_field = 1 },
            { type = compat.unsigned, name = 's1'                    },
            { type = compat.string,   name = 's2'                    },
        }
    })
```

field `add_field` causes schema parsing to fail with error
`Failed to parse schema (space)'`

Also added support for Tarantool 1.9+ tests