### PR TITLE
Fix select() by space_no and index_name

### DIFF
--- a/src/tarantool_proto.h
+++ b/src/tarantool_proto.h
@@ -12,6 +12,8 @@
 #define SPACE_SPACE 281
 #define SPACE_INDEX 289
 
+#define INDEX_SPACE_NO      0
+#define INDEX_INDEX_NO      0
 #define INDEX_SPACE_NAME    2
 #define INDEX_INDEX_NAME    2
 

--- a/src/tarantool_schema.c
+++ b/src/tarantool_schema.c
@@ -558,6 +558,25 @@ tarantool_schema_get_sid_by_string(
 }
 
 int32_t
+tarantool_schema_get_sid_by_number(
+		struct tarantool_schema *schema_obj,
+		uint32_t sid
+) {
+	struct mh_schema_space_t *schema = schema_obj->space_hash;
+	struct schema_key space_key = {
+		(void *)&sid,
+		sizeof(uint32_t),
+		sid, /* ignored */
+	};
+	mh_int_t space_slot = mh_schema_space_find(schema, &space_key, NULL);
+	if (space_slot == mh_end(schema))
+		return -1;
+	const struct schema_space_value *space =
+		*mh_schema_space_node(schema, space_slot);
+	return space->space_number;
+}
+
+int32_t
 tarantool_schema_get_iid_by_string(
 		struct tarantool_schema *schema_obj, uint32_t sid,
 		const char *index_name, uint32_t index_name_len

--- a/src/tarantool_schema.h
+++ b/src/tarantool_schema.h
@@ -56,6 +56,8 @@ int32_t
 tarantool_schema_get_sid_by_string(struct tarantool_schema *, const char *,
 				   uint32_t);
 int32_t
+tarantool_schema_get_sid_by_number(struct tarantool_schema *, uint32_t);
+int32_t
 tarantool_schema_get_iid_by_string(struct tarantool_schema *, uint32_t,
 				   const char *, uint32_t);
 int32_t


### PR DESCRIPTION
When a space exists, but a client side schema does not know about it at
the moment (say, right after connection), and when a user calls select()
with a space id (number) and name of an index (string), the problem
appears: the client raises the following error:

```
TarantoolParsingException: Failed to parse schema (index)
```

However it should successfully perform the request.

The problem is that when there is no record for a space in client's
schema, it is not possible to save a record for an index of this space.

The idea of the fix is to verify whether we know about a space even when
a numeric ID is already provided. If a client has no record about the 
space, it fetches a schema and verify whether the space appears. If so, 
there is no more problem described above. Otherwise the client raises an
error that the space with given ID does not exist.

While we're here, ensure that return values of tarantool_schema_*() are 
checked against -1, not Zend's FAILURE macro (which is only guaranteed
to be less than zero) in the modified code. Also ensure that the FAILURE
macro is returned from the get_spaceno_by_name() function, not -1. 

Closes #42 