### PR TITLE
No more assertion on 0 connection retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Place it into project library path in your IDE.
 
 * `tarantool.persistent` - Enable persistent connections (don't close connections between sessions) (defaults: True, **can't be changed in runtime**)
 * `tarantool.timeout` - Connection timeout (defaults: 10 seconds, can be changed in runtime)
-* `tarantool.retry_count` - Count of retries for connecting (defaults: 1, can be changed in runtime)
+* `tarantool.retry_count` - Count of retries for connecting (defaults: 0, can be changed in runtime). 0 means do not retry in case the connection was failed the first time.
 * `tarantool.retry_sleep` - Sleep between connecting retries (defaults: 0.1 second, can be changed in runtime)
 * `tarantool.request_timeout` - Read/write timeout for requests (defaults: 10 second, can be changed in runtime)
 

--- a/src/tarantool.c
+++ b/src/tarantool.c
@@ -117,7 +117,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("tarantool.request_timeout", "3600.0", PHP_INI_ALL,
 			  OnUpdateReal, request_timeout, zend_tarantool_globals,
 			  tarantool_globals)
-	STD_PHP_INI_ENTRY("tarantool.retry_count", "1", PHP_INI_ALL,
+	STD_PHP_INI_ENTRY("tarantool.retry_count", "0", PHP_INI_ALL,
 			  OnUpdateLong, retry_count, zend_tarantool_globals,
 			  tarantool_globals)
 	STD_PHP_INI_ENTRY("tarantool.retry_sleep", "10", PHP_INI_ALL,
@@ -252,7 +252,12 @@ static int __tarantool_connect(tarantool_object *t_obj) {
 	TSRMLS_FETCH();
 	tarantool_connection *obj = t_obj->obj;
 	int status = SUCCESS;
-	long count = TARANTOOL_G(retry_count);
+	/*
+	 * Amount of connection attempts is always 1 more than
+	 * `retry_count` option value, since the option means
+	 * amount of attempts after the first one.
+	 */
+	long count = TARANTOOL_G(retry_count) + 1;
 	struct timespec sleep_time = {0};
 	double_to_ts(INI_FLT("retry_sleep"), &sleep_time);
 	char *err = NULL;
@@ -962,7 +967,7 @@ PHP_RINIT_FUNCTION(tarantool) {
 
 static void php_tarantool_init_globals(zend_tarantool_globals *tarantool_globals) {
 	tarantool_globals->sync_counter    = 0;
-	tarantool_globals->retry_count     = 1;
+	tarantool_globals->retry_count     = 0;
 	tarantool_globals->retry_sleep     = 10;
 	tarantool_globals->timeout         = 3600.0;
 	tarantool_globals->request_timeout = 3600.0;

--- a/test/CreateTest.php
+++ b/test/CreateTest.php
@@ -163,5 +163,28 @@ class CreateTest extends TestCase
             ['guest', null],
         ];
     }
+
+    public function test_10_zero_retry_exception() {
+        /*
+         * gh-83: An attempt to connection with `retry_count = 0`
+         * gives the following error:
+         *
+         *  | Uncaught TarantoolIOException: (null)
+         *
+         * Now the option means amount of attempts to connect
+         * after the first one, not an overall attempts to
+         * connect. So zero becomes valid value.
+         */
+
+        $saved_retry_count = ini_get('tarantool.retry_count');
+        ini_set('tarantool.retry_count', 0);
+
+        try {
+            $c = new Tarantool('localhost', self::$port);
+            $this->assertEquals($c->ping(), true);
+        } finally {
+            ini_set('tarantool.retry_count', $saved_retry_count);
+        }
+    }
 }
 


### PR DESCRIPTION
This commit changes meanging of the `retry_count` option: now it means
amount of attempts to connect after the first one, not overall attempts
count.

Closes #83