### PR TITLE
build/debian: auto-enable extension

### DIFF
--- a/debian/php-tarantool.postinst.in
+++ b/debian/php-tarantool.postinst.in
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "configure" ]; then
+    if [ -e /usr/lib/php/php-maintscript-helper ] ; then
+	. /usr/lib/php/php-maintscript-helper
+	php_invoke enmod ${phpversion} ALL tarantool
+    fi
+fi
+
+exit 0

--- a/debian/php-tarantool.postrm.in
+++ b/debian/php-tarantool.postrm.in
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "remove" ]; then
+    if [ -e /usr/lib/php/php-maintscript-helper ] ; then
+	. /usr/lib/php/php-maintscript-helper
+	php_invoke dismod ${phpversion} ALL tarantool
+    fi
+fi
+
+exit 0

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -16,3 +16,8 @@ phpversion=$(php-config --version | sed 's/^\([0-9]\+\.[0-9]\).*/\1/')
 cd /build/php-tarantool-*
 sed -e "s/\${phpversion}/${phpversion}/" debian/control.in > debian/control
 rm debian/control.in
+
+sed -e "s/\${phpversion}/${phpversion}/" debian/php-tarantool.postinst.in \
+    > debian/php${phpversion}-tarantool.postinst
+sed -e "s/\${phpversion}/${phpversion}/" debian/php-tarantool.postrm.in \
+    > debian/php${phpversion}-tarantool.postrm

--- a/debian/rules
+++ b/debian/rules
@@ -24,10 +24,6 @@ install/php$(phpversion)-tarantool::
 		debian/php$(phpversion)-tarantool/usr/lib/php/$(phpapi)/
 	echo extension=tarantool.so \
 		> debian/php$(phpversion)-tarantool/etc/php/$(phpversion)/mods-available/tarantool.ini
-	# Enable the extension.
-	install -m 0755 -d debian/php$(phpversion)-tarantool/etc/php/$(phpversion)/cli/conf.d
-	ln -s /etc/php/$(phpversion)/mods-available/tarantool.ini \
-		debian/php$(phpversion)-tarantool/etc/php/$(phpversion)/cli/conf.d/50-tarantool.ini
 
 clean::
 	phpize --clean


### PR DESCRIPTION
use phpenmod/phpdismod to auto-enable/disable tarantool
extension on all installed SAPIs.

this also reverts 40d8795aaf1956b24e41d77d561dae1cd369d934.
