### PR TITLE
travis-ci: update Ubuntu versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ jobs:
     - env: OS=debian DIST=buster
     - env: OS=ubuntu DIST=xenial
     - env: OS=ubuntu DIST=bionic
-    - env: OS=ubuntu DIST=disco
     - env: OS=ubuntu DIST=eoan
+    - env: OS=ubuntu DIST=focal
 
 python:
   - 2.7

--- a/test.pkg.all.sh
+++ b/test.pkg.all.sh
@@ -15,8 +15,8 @@ distros="
     debian:buster
     ubuntu:xenial
     ubuntu:bionic
-    ubuntu:disco
     ubuntu:eoan
+    ubuntu:focal
 "
 
 if ! type packpack; then


### PR DESCRIPTION
Dropped Ubuntu Disco, which is EOL.

Added Ubuntu Focal.

Fixes #159