### PR TITLE
Give meaningful error when retry_count is zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Place it into project library path in your IDE.
 
 * `tarantool.persistent` - Enable persistent connections (don't close connections between sessions) (defaults: True, **can't be changed in runtime**)
 * `tarantool.timeout` - Connection timeout (defaults: 10 seconds, can be changed in runtime)
-* `tarantool.retry_count` - Count of retries for connecting (defaults: 1, can be changed in runtime)
+* `tarantool.retry_count` - Amount of attempts to connect (defaults: 1, can be changed in runtime)
 * `tarantool.retry_sleep` - Sleep between connecting retries (defaults: 0.1 second, can be changed in runtime)
 * `tarantool.request_timeout` - Read/write timeout for requests (defaults: 10 second, can be changed in runtime)
 

--- a/src/tarantool.c
+++ b/src/tarantool.c
@@ -257,6 +257,11 @@ static int __tarantool_connect(tarantool_object *t_obj) {
 	double_to_ts(INI_FLT("retry_sleep"), &sleep_time);
 	char *err = NULL;
 
+	if (count < 1) {
+		THROW_EXC("tarantool.retry_count should be 1 or above");
+		return FAILURE;
+	}
+
 	if (t_obj->is_persistent) {
 		if (!obj->persistent_id)
 			obj->persistent_id = pid_pzsgen(obj->host, obj->port,

--- a/test/shared/box.lua
+++ b/test/shared/box.lua
@@ -180,5 +180,22 @@ function test_6(...)
     return ...
 end
 
+iproto_connect_counter = 0
+function iproto_connect_count()
+    return iproto_connect_counter
+end
+
+box.session.on_connect(function()
+    -- box.session.type() was introduced in 1.7.4-370-g0bce2472b.
+    --
+    -- We're interested in iproto sessions, but it is okay for our
+    -- usage scenario to count replication and console sessions
+    -- too: we only see to a delta and AFAIK our testing harness
+    -- does not perform any background reconnections.
+    if box.session.type == nil or box.session.type() == 'binary' then
+        iproto_connect_counter = iproto_connect_counter + 1
+    end
+end)
+
 require('console').listen(os.getenv('ADMIN_PORT'))
 


### PR DESCRIPTION
Clarified docs about this setting.

There may be a confusion whether the setting means overall amount of
connection attempts or amount after the initial unsuccessful attempt.
Usually a retries amount option means the latter, but here it means the
former.

Decided to don't change behaviour or the setting name to provide perfect
backward compatibility, but give meaningful error and clarify docs. See
the discussion in [1].

[1]: https://github.com/tarantool/tarantool-php/pull/145#discussion_r241255667

Fixes #83