### PR TITLE
Support call 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ _**Description**_: Evaluate given lua code (demands current user to have
 
 _**Parameters**_
 * `expression`: String, Lua code to evaluate (mandatory)
-* `args`: Any value to pass to procdure as arguments (empty by default)
+* `args`: Any value to pass to procedure as arguments (empty by default)
 
 _**Return Value**_
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Tarantool {
     public array Tarantool::select (mixed $space [, mixed $key = array() [, mixed $index = 0 [, int $limit = PHP_INT_MAX [, int $offset = 0 [, $iterator = Tarantool::ITERATOR_EQ ] ] ] ] ] )
     public array Tarantool::insert (mixed $space, array $tuple)
     public array Tarantool::replace (mixed $space, array $tuple)
-    public array Tarantool::call (string $procedure [, mixed args] )
+    public array Tarantool::call (string $procedure [, mixed args [, array $opts ] ] )
     public array Tarantool::evaluate (string $expression [, mixed args] )
     public array Tarantool::delete (mixed $space, mixed $key [, mixed $index] )
     public array Tarantool::update (mixed $space, mixed $key, array $ops [, number $index] )
@@ -299,27 +299,47 @@ $tnt->replace("test", array(1, 3, "smth completely different"));
 ### Tarantool::call
 
 ``` php
-public array Tarantool::call(string $procedure [, mixed args])
+public array Tarantool::call(string $procedure [, mixed args [, array $opts]])
 ```
 
 _**Description**_: Call stored procedure
 
 _**Parameters**_
 * `procedure`: String, procedure to call (mandatory)
-* `args`: Any value to pass to procdure as arguments (empty by default)
+* `args`: Any value to pass to procedure as arguments (empty by default)
+* `opts`: Array, options
+
+_**Options**_
+* call_16<br />
+  If true - call_16 mode of "call" will be used
+  (returned data converted to tuples).<br />
+  If false - call_17 mode of "call" will be used
+  (returned data has an arbitrary structure). Since tarantool 1.7.2.<br />
+  Default - call_16 mode.
+  ```
+  array(
+    "call_16" => <bool>
+  ),
+  ```
 
 _**Return Value**_
+
+**BOOL**: False and raises `Exception` in case of error.
+
+call_16 mode (default):
 
 **Array of arrays** in case of success - tuples that were returned by stored
  procedure.
 
-**BOOL**: False and raises `Exception` in case of error.
+call_17 mode:
+
+**Any value**, that was returned by stored procedure.
 
 #### Example
 
 ``` php
 $tnt->call("test_2");
-$tnt->call("test_3", array(3, 4));
+$tnt->call("test_3", array(3, 4), array('call_16' => false));
 ```
 
 ### Tarantool::evaluate

--- a/src/tarantool_proto.h
+++ b/src/tarantool_proto.h
@@ -87,10 +87,11 @@ enum tnt_request_type {
 	TNT_REPLACE = 0x03,
 	TNT_UPDATE  = 0x04,
 	TNT_DELETE  = 0x05,
-	TNT_CALL    = 0x06,
+	TNT_CALL_16 = 0x06,
 	TNT_AUTH    = 0x07,
 	TNT_EVAL    = 0x08,
 	TNT_UPSERT  = 0x09,
+	TNT_CALL    = 0x0a,
 	TNT_PING    = 0x40
 };
 
@@ -138,6 +139,8 @@ void php_tp_encode_delete(smart_string *str, uint32_t sync, uint32_t space_no,
 			  uint32_t index_no, zval *tuple);
 void php_tp_encode_call(smart_string *str, uint32_t sync, char *proc,
 			uint32_t proc_len, zval *tuple);
+void php_tp_encode_call_16(smart_string *str, uint32_t sync, char *proc,
+			   uint32_t proc_len, zval *tuple);
 void php_tp_encode_eval(smart_string *str, uint32_t sync, char *proc,
 			uint32_t proc_len, zval *tuple);
 

--- a/test/DMLTest.php
+++ b/test/DMLTest.php
@@ -235,7 +235,8 @@ class DMLTest extends TestCase
     }
 
     public function test_12_call() {
-        $result = self::$tarantool->call("test_6", array(true, false, false));
+        $result = self::$tarantool->call("test_6", array(true, false, false),
+                                         array('call_16' => true));
         $this->assertEquals(array(array(true), array(false), array(false)), $result);
         $this->assertEquals(
             array(
@@ -243,10 +244,28 @@ class DMLTest extends TestCase
                     '0' => array('k1' => 'v2', 'k2' => 'v')
                 )
             ),
-            self::$tarantool->call("test_2")
+            self::$tarantool->call("test_2", array(), array('call_16' => true))
         );
         $this->assertEquals(
-            self::$tarantool->call("test_3", array(3, 4)), array('0' => array('0' => 7)));
+            self::$tarantool->call("test_3", array(3, 4), array('call_16' => true)),
+            array('0' => array('0' => 7))
+        );
+
+        $check_call_17 = self::$tarantool->call('tarantool_version_at_least',
+                                                array(1, 7, 2, 0));
+        if ($check_call_17[0][0]) {
+            $result = self::$tarantool->call("test_6", array(true, false, false),
+                                             array('call_16' => false));
+            $this->assertEquals(array(true, false, false), $result);
+            $this->assertEquals(
+                array('0' => array('k1' => 'v2', 'k2' => 'v')),
+                self::$tarantool->call("test_2", array(), array('call_16' => false))
+            );
+            $this->assertEquals(
+                self::$tarantool->call("test_3", array(3, 4), array('call_16' => false)),
+                array('0' => 7)
+            );
+        }
     }
 
     public function test_13_eval() {

--- a/test/MsgPackTest.php
+++ b/test/MsgPackTest.php
@@ -22,14 +22,31 @@ class MsgPackTest extends TestCase
             '4TL2tLIXqMqyGQm_kiE7mRrS96I5E8nqU', 'B627', 0, [
                 'browser_stats_first_session_hits' => 1
             ]
-        ]);
+        ], ['call_16' => true]);
         $this->assertEquals($resp[0][0], 2);
         $resp = self::$tarantool->call('test_4', [
             '4TL2tLIXqMqyGQm_kiE7mRrS96I5E8nqU', 'B627', 0, [
                 'browser_stats_first_session_hit' => 1
             ]
-        ]);
+        ], ['call_16' => true]);
         $this->assertEquals($resp[0][0], 2);
+
+        $check_call_17 = self::$tarantool->call('tarantool_version_at_least',
+                                                array(1,7,2,0));
+        if ($check_call_17[0][0]) {
+            $resp = self::$tarantool->call('test_4', [
+                '4TL2tLIXqMqyGQm_kiE7mRrS96I5E8nqU', 'B627', 0, [
+                    'browser_stats_first_session_hits' => 1
+                ]
+            ], ['call_16' => false]);
+            $this->assertEquals($resp[0], 2);
+            $resp = self::$tarantool->call('test_4', [
+                '4TL2tLIXqMqyGQm_kiE7mRrS96I5E8nqU', 'B627', 0, [
+                    'browser_stats_first_session_hit' => 1
+                ]
+            ], ['call_16' => false]);
+            $this->assertEquals($resp[0], 2);
+        }
     }
 
     public function test_01_msgpack_array_key() {
@@ -81,6 +98,6 @@ class MsgPackTest extends TestCase
     public function test_06_msgpack_array_reference() {
         $data = array('key1' => 'value1');
         $link = &$data['key1'];
-        self::$tarantool->call('test_4', [$data]);
+        self::$tarantool->call('test_4', [$data], ['call_16' => true]);
     }
 }

--- a/test/RandomTest.php
+++ b/test/RandomTest.php
@@ -42,8 +42,19 @@ class RandomTest extends TestCase
 
     public function test_03_another_big_response() {
         for ($i = 100; $i <= 5200; $i += 100) {
-            $result = self::$tarantool->call('test_5', array($i));
+            $result = self::$tarantool->call('test_5', array($i),
+                                             array('call_16' => true));
             $this->assertEquals($i, count($result));
+        }
+
+        $check_call_17 = self::$tarantool->call('tarantool_version_at_least',
+                                                array(1,7,2,0));
+        if ($check_call_17[0][0]) {
+            for ($i = 100; $i <= 5200; $i += 100) {
+                $result = self::$tarantool->call('test_5', array($i),
+                                                 array('call_16' => false));
+                $this->assertEquals($i, count($result[0]));
+            }
         }
     }
 

--- a/test/shared/box.lua
+++ b/test/shared/box.lua
@@ -223,5 +223,8 @@ box.session.on_connect(function()
     end
 end)
 
+-- export tarantool_version_at_least function
+_G.tarantool_version_at_least = tarantool_version_at_least
+
 require('console').listen(os.getenv('ADMIN_PORT'))
 


### PR DESCRIPTION
    * Added support for a new binary protocol command for "call" (used
      since tarantool 1.7.2). Unlike the old version, returned data is
      not converted to tuples (like in case of using "eval").
      Default - call_16 mode.
    * Added options to "call" method. It can be used to force
      call_16 / call_17 mode.

In some places, the tarantool code style has been broken to better match the file code style.

Closes #101

ChangeLog: added support of a new binary protocol command for "call"(call_17 mode since tarantool 1.7.2, returned data has an arbitrary structure). 