### PR TITLE
code health: don't mix FAILURE and -1 in get_spaceno_by_name()

### DIFF
--- a/src/tarantool.c
+++ b/src/tarantool.c
@@ -694,6 +694,7 @@ int get_spaceno_by_name(tarantool_connection *obj, zval *name) {
 							      Z_LVAL_P(name));
 		if (space_no == -1) {
 			THROW_EXC("No space %d defined", Z_LVAL_P(name));
+			return FAILURE;
 		}
 	} else {
 		space_no = tarantool_schema_get_sid_by_string(obj->schema,
@@ -701,6 +702,7 @@ int get_spaceno_by_name(tarantool_connection *obj, zval *name) {
 							      Z_STRLEN_P(name));
 		if (space_no == -1) {
 			THROW_EXC("No space '%s' defined", Z_STRVAL_P(name));
+			return FAILURE;
 		}
 	}
 


### PR DESCRIPTION
Technically we should return FAILURE (not -1) from the changed function
in case of a failure. FAILURE is -1 in fact and it unlikely will be
changed, but the only formal guarantee we have is that FAILURE is a
negative value.

Cited from [1]:

```
typedef enum {
  SUCCESS =  0,
  FAILURE = -1,		/* this MUST stay a negative number, or it may affect functions! */
} ZEND_RESULT_CODE;
```

No behaviour actually changed in this commit.

It is the follow up for 5647d24667a48ca3e9242c33fca86ab73b580652 ('Fix
select() by space_no and index_name'), where we initially set eyes on
this point.

[1]: https://github.com/php/php-src/blob/4903f7c5fde11a115f659ec54a1d0ede6fd7232c/Zend/zend_types.h#L53-L56

Follows up #42.