### PR TITLE
Send auth method name in auth request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ Makefile.in
 *.pyc
 *.out
 *.dSYM
+*.dep
 var*
 config.guess.cdbs-orig
 config.sub.cdbs-orig

--- a/src/third_party/tp.h
+++ b/src/third_party/tp.h
@@ -715,6 +715,9 @@ enum tp_request_type {
 
 static const uint32_t SCRAMBLE_SIZE = 20;
 
+static const char* AUTH_METHOD = "chap-sha1";
+static const uint32_t AUTH_METHOD_SIZE = 9;
+
 /**
  * Receive greetings from the server.
  * Note, the input buffer is not copied,
@@ -1289,7 +1292,7 @@ tp_auth(struct tp *p, const char *salt_base64, const char *user, int ulen, const
 		mp_sizeof_uint(TP_TUPLE);
 	if (!nopass)
 		sz += mp_sizeof_array(2) +
-		      mp_sizeof_str(0) +
+		      mp_sizeof_str(AUTH_METHOD_SIZE) +
 		      mp_sizeof_str(SCRAMBLE_SIZE);
 	else
 		sz += mp_sizeof_array(0);
@@ -1310,7 +1313,7 @@ tp_auth(struct tp *p, const char *salt_base64, const char *user, int ulen, const
 	h = mp_encode_uint(h, TP_TUPLE);
 	if (!nopass) {
 		h = mp_encode_array(h, 2);
-		h = mp_encode_str(h, 0, 0);
+		h = mp_encode_str(h, AUTH_METHOD, AUTH_METHOD_SIZE);
 
 		// char salt[64];
 		zend_string *salt = NULL;


### PR DESCRIPTION
Sending empty auth method name in authentication request result in error from recent versions of tarantool. This PR adds sending default auth method name "chap-sha1" in authentication request.
