### PR TITLE
Fix authentication to Tarantool >= 2.11

### DIFF
--- a/src/third_party/tp.h
+++ b/src/third_party/tp.h
@@ -715,6 +715,9 @@ enum tp_request_type {
 
 static const uint32_t SCRAMBLE_SIZE = 20;
 
+static const char* CHAP_SHA1_AUTH_METHOD = "chap-sha1";
+static const uint32_t CHAP_SHA1_AUTH_METHOD_SIZE = 9;
+
 /**
  * Receive greetings from the server.
  * Note, the input buffer is not copied,
@@ -1289,7 +1292,7 @@ tp_auth(struct tp *p, const char *salt_base64, const char *user, int ulen, const
 		mp_sizeof_uint(TP_TUPLE);
 	if (!nopass)
 		sz += mp_sizeof_array(2) +
-		      mp_sizeof_str(0) +
+		      mp_sizeof_str(CHAP_SHA1_AUTH_METHOD_SIZE) +
 		      mp_sizeof_str(SCRAMBLE_SIZE);
 	else
 		sz += mp_sizeof_array(0);
@@ -1310,7 +1313,7 @@ tp_auth(struct tp *p, const char *salt_base64, const char *user, int ulen, const
 	h = mp_encode_uint(h, TP_TUPLE);
 	if (!nopass) {
 		h = mp_encode_array(h, 2);
-		h = mp_encode_str(h, 0, 0);
+		h = mp_encode_str(h, CHAP_SHA1_AUTH_METHOD, CHAP_SHA1_AUTH_METHOD_SIZE);
 
 		// char salt[64];
 		zend_string *salt = NULL;

--- a/test/CreateTest.php
+++ b/test/CreateTest.php
@@ -107,8 +107,8 @@ class CreateTest extends TestCase
         $this->assertTrue($c->ping());
 
         $this->expectException(TarantoolClientError::class);
-        $this->expectExceptionMessage(
-            'Incorrect password supplied for user');
+        $this->expectExceptionMessageMatches(
+            '/(Incorrect password supplied for user)|(User not found or supplied credentials are invalid)/');
         $c->authenticate('test', 'bad_password');
     }
 
@@ -118,8 +118,8 @@ class CreateTest extends TestCase
         $this->assertTrue($c->ping());
 
         $this->expectException(TarantoolClientError::class);
-        $this->expectExceptionMessage(
-            'Incorrect password supplied for user');
+        $this->expectExceptionMessageMatches(
+            '/(Incorrect password supplied for user)|(User not found or supplied credentials are invalid)/');
         $c->authenticate('guest', 'guest');
     }
 

--- a/test/DMLTest.php
+++ b/test/DMLTest.php
@@ -361,7 +361,7 @@ class DMLTest extends TestCase
             self::$tarantool->select("test_hash", null, null, null, null, TARANTOOL::ITERATOR_EQ);
             $this->assertFalse(True);
         } catch (TarantoolClientError $e) {
-            $this->assertRegExp('(Invalid key part|via a partial key)', $e->getMessage());
+            $this->assertMatchesRegularExpression('(Invalid key part|via a partial key)', $e->getMessage());
         }
     }
 
@@ -373,7 +373,7 @@ class DMLTest extends TestCase
             self::$tarantool->select($spc, null, null, null, null, $itype);
             $this->assertFalse(True);
         } catch (TarantoolClientError $e) {
-            $this->assertRegExp($xcmsg, $e->getMessage());
+            $this->assertMatchesRegularExpression($xcmsg, $e->getMessage());
         }
     }
 

--- a/test/PhpUnitCompat.php
+++ b/test/PhpUnitCompat.php
@@ -231,6 +231,28 @@ if ($testCaseRef->hasMethod('expectExceptionMessageMatches')) {
 }
 
 /*
+ * AssertMatchesRegularExpressionTrait (private).
+ *
+ * phpunit-8 provides the new name for the
+ * assertRegExp() method:
+ * assertMatchesRegularExpression(). phpunit-10 removes the old name.
+ *
+ * This trait adds assertMatchesRegularExpression() method for
+ * phpunit-6, phpunit-7, phpunit-8 and phpunit-9.
+ */
+if ($testCaseRef->hasMethod('assertMatchesRegularExpression')) {
+    trait AssertMatchesRegularExpressionTrait {
+        /* Nothing to define. */
+    }
+} else {
+    trait AssertMatchesRegularExpressionTrait {
+        public function assertMatchesRegularExpression($pattern, $string, $message = '') {
+            self::assertRegExp($pattern, $string, $message);
+        }
+    }
+}
+
+/*
  * TestCaseCompat (public).
  *
  * This trait accumulates all hacks defined above.
@@ -240,4 +262,5 @@ trait TestCaseCompat
     use SetUpTearDownTrait;
     use AssertStringContainsStringTrait;
     use ExpectExceptionMessageMatchesTrait;
+    use AssertMatchesRegularExpressionTrait;
 }

--- a/test/shared/phpunit.xml
+++ b/test/shared/phpunit.xml
@@ -11,7 +11,6 @@
       <file>test/DMLTest.php</file>
       <file>test/MockTest.php</file>
       <file>test/MsgPackTest.php</file>
-      <file>test/AssertTest.php</file>
       <file>test/RandomTest.php</file>
     </testsuite>
   </testsuites>


### PR DESCRIPTION
The authentication method is checked on the server-side since Tarantool 2.11 [1]. In fact, this has been required before [2].

So we need to add the authorization method value into the `AUTH_REQUEST`.

1. https://github.com/tarantool/tarantool/commit/b5754d3fb404641ac35c2601be4777e1db0890bb
2. https://www.tarantool.io/en/doc/1.10/dev_guide/internals_index/#authentication